### PR TITLE
Remove broken logo from README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# Coefeasy <img src="man/figures/coefeasy_logo.png" width="160px" align="right"/>
+# Coefeasy
 
 <!-- badges: start -->
 


### PR DESCRIPTION
## Summary
- remove the broken logo image from the README heading so only the package title remains


